### PR TITLE
Feature enable jmxremote by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.9.10
 * Migrate artifacts deployment tools from aem-aws-stack-provisioner to aem_curator
+* Add feature enable jmxremote at AEM Author and Publish java instances
 
 ### 0.9.9
 * Migrate all AEM Tools files and templates from aem-aws-stack-provisioner to aem_curator

--- a/manifests/config_author_primary.pp
+++ b/manifests/config_author_primary.pp
@@ -193,7 +193,7 @@ class aem_curator::config_author_primary (
 
   collectd::plugin::genericjmx::connection { 'aem':
     host        => $::fqdn,
-    service_url => 'service:jmx:rmi:///jndi/rmi://localhost:8463/jmxrmi',
+    service_url => "service:jmx:rmi:///jndi/rmi://localhost:${jmxremote_port}/jmxrmi",
     collect     => [ 'standby-status' ],
   }
 

--- a/manifests/config_author_primary.pp
+++ b/manifests/config_author_primary.pp
@@ -5,6 +5,9 @@
 # [*jvm_mem_opts*]
 #   User defined JVM Memory options to be passed to the AEM Author
 #
+# [*jmxremote_port*]
+#   User defined Port on which JMXRemote is listening
+#
 # === Copyright
 #
 # Copyright © 2017 Shine Solutions Group, unless otherwise noted.

--- a/manifests/config_author_primary.pp
+++ b/manifests/config_author_primary.pp
@@ -33,7 +33,7 @@ class aem_curator::config_author_primary (
   $tmp_dir,
   $aem_id                  = 'author',
   $delete_repository_index = false,
-  $jmxremote_port          = '59185',
+  $jmxremote_port          = '59182',
   $jvm_mem_opts            = undef,
   $run_mode                = 'author',
 ) {

--- a/manifests/config_author_primary.pp
+++ b/manifests/config_author_primary.pp
@@ -30,6 +30,7 @@ class aem_curator::config_author_primary (
   $tmp_dir,
   $aem_id                  = 'author',
   $delete_repository_index = false,
+  $jmxremote_port          = '59185',
   $jvm_mem_opts            = undef,
   $run_mode                = 'author',
 ) {
@@ -54,6 +55,16 @@ class aem_curator::config_author_primary (
       path   => "${crx_quickstart_dir}/bin/start-env",
       line   => "JVM_MEM_OPTS='${jvm_mem_opts}'",
       match  => '^JVM_MEM_OPTS',
+    }
+  }
+
+  if $jmxremote_port {
+    file_line { "${aem_id}: enable JMXRemote":
+      ensure => present,
+      path   => "${crx_quickstart_dir}/bin/start-env",
+      line   => "JVM_OPTS=\"\$JVM_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${jmxremote_port} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=true -Djava.rmi.server.hostname=localhost\"",
+      after  => '^JVM_OPTS'
+      notify => Service['aem-author'],
     }
   }
 

--- a/manifests/config_author_primary.pp
+++ b/manifests/config_author_primary.pp
@@ -66,7 +66,7 @@ class aem_curator::config_author_primary (
       ensure => present,
       path   => "${crx_quickstart_dir}/bin/start-env",
       line   => "JVM_OPTS=\"\$JVM_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${jmxremote_port} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=true -Djava.rmi.server.hostname=localhost\"",
-      after  => '^JVM_OPTS'
+      after  => '^JVM_OPTS',
       notify => Service['aem-author'],
     }
   }

--- a/manifests/config_author_standby.pp
+++ b/manifests/config_author_standby.pp
@@ -65,7 +65,7 @@ class aem_curator::config_author_standby (
       ensure => present,
       path   => "${crx_quickstart_dir}/bin/start-env",
       line   => "JVM_OPTS=\"\$JVM_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${jmxremote_port} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=true -Djava.rmi.server.hostname=localhost\"",
-      after  => '^JVM_OPTS'
+      after  => '^JVM_OPTS',
       notify => Service['aem-author'],
     }
   }

--- a/manifests/config_author_standby.pp
+++ b/manifests/config_author_standby.pp
@@ -5,6 +5,9 @@
 # [*jvm_mem_opts*]
 #   User defined JVM Memory options to be passed to the AEM Author
 #
+# [*jmxremote_port*]
+#   User defined Port on which JMXRemote is listening
+#
 # === Copyright
 #
 # Copyright © 2017 Shine Solutions Group, unless otherwise noted.

--- a/manifests/config_author_standby.pp
+++ b/manifests/config_author_standby.pp
@@ -32,7 +32,7 @@ class aem_curator::config_author_standby (
   $tmp_dir,
   $aem_id                  = 'author',
   $delete_repository_index = false,
-  $jmxremote_port          = '59185',
+  $jmxremote_port          = '59182',
   $jvm_mem_opts            = undef,
   $run_mode                = 'author',
 ) {

--- a/manifests/config_author_standby.pp
+++ b/manifests/config_author_standby.pp
@@ -168,7 +168,7 @@ class aem_curator::config_author_standby (
 
   collectd::plugin::genericjmx::connection { 'aem':
     host        => $::fqdn,
-    service_url => 'service:jmx:rmi:///jndi/rmi://localhost:${jmxremote_port}/jmxrmi',
+    service_url => "service:jmx:rmi:///jndi/rmi://localhost:${jmxremote_port}/jmxrmi",
     collect     => [ 'standby-status' ],
   }
 

--- a/manifests/config_collectd.pp
+++ b/manifests/config_collectd.pp
@@ -21,7 +21,7 @@ class aem_curator::config_collectd (
       instance_from   => 'name',
       values          => [
         {
-          mbean_typee => 'invocations',
+          mbean_type  => 'invocations',
           table       => false,
           attribute   => 'CollectionCount',
         },

--- a/manifests/config_collectd.pp
+++ b/manifests/config_collectd.pp
@@ -21,12 +21,12 @@ class aem_curator::config_collectd (
       instance_from   => 'name',
       values          => [
         {
-          'type'    => 'invocations',
-          table     => false,
-          attribute => 'CollectionCount',
+          mbean_typee => 'invocations',
+          table       => false,
+          attribute   => 'CollectionCount',
         },
         {
-          'type'          => 'total_time_in_ms',
+          mbean_type      => 'total_time_in_ms',
           instance_prefix => 'collection_time',
           table           => false,
           attribute       => 'CollectionTime',
@@ -37,9 +37,9 @@ class aem_curator::config_collectd (
       instance_prefix => 'memory-heap',
       values          => [
         {
-          'type'    => 'jmx_memory',
-          table     => true,
-          attribute => 'HeapMemoryUsage',
+          mbean_type  => 'jmx_memory',
+          table       => true,
+          attribute   => 'HeapMemoryUsage',
         },
       ];
     'memory-nonheap':
@@ -47,9 +47,9 @@ class aem_curator::config_collectd (
       instance_prefix => 'memory-nonheap',
       values          => [
         {
-          'type'    => 'jmx_memory',
-          table     => true,
-          attribute => 'NonHeapMemoryUsage',
+          mbean_type  => 'jmx_memory',
+          table       => true,
+          attribute   => 'NonHeapMemoryUsage',
         },
       ];
     'memory-permgen':
@@ -57,9 +57,9 @@ class aem_curator::config_collectd (
       instance_prefix => 'memory-permgen',
       values          => [
         {
-          'type'    => 'jmx_memory',
-          table     => true,
-          attribute => 'Usage',
+          mbean_type  => 'jmx_memory',
+          table       => true,
+          attribute   => 'Usage',
         },
       ];
   }

--- a/manifests/config_publish.pp
+++ b/manifests/config_publish.pp
@@ -5,6 +5,9 @@
 # [*jvm_mem_opts*]
 #   User defined JVM Memory options to be passed to AEM Publisher
 #
+# [*jmxremote_port*]
+#   User defined Port on which JMXRemote is listening
+#
 # === Copyright
 #
 # Copyright © 2017 Shine Solutions Group, unless otherwise noted.
@@ -38,6 +41,7 @@ class aem_curator::config_publish (
   $vol_type,
   $aem_id                  = 'publish',
   $delete_repository_index = false,
+  $jmxremote_port          = '59185',
   $jvm_mem_opts            = undef,
   $run_mode                = 'publish',
   $snapshotid              = $::snapshotid,
@@ -74,6 +78,16 @@ class aem_curator::config_publish (
       path   => "${crx_quickstart_dir}/bin/start-env",
       line   => "JVM_MEM_OPTS='${jvm_mem_opts}'",
       match  => '^JVM_MEM_OPTS',
+    }
+  }
+
+  if $jmxremote_port {
+    file_line { "${aem_id}: enable JMXRemote":
+      ensure => present,
+      path   => "${crx_quickstart_dir}/bin/start-env",
+      line   => "JVM_OPTS=\"\$JVM_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${jmxremote_port} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=true -Djava.rmi.server.hostname=localhost\"",
+      after  => '^JVM_OPTS'
+      notify => Service['aem-author'],
     }
   }
 

--- a/manifests/config_publish.pp
+++ b/manifests/config_publish.pp
@@ -41,7 +41,7 @@ class aem_curator::config_publish (
   $vol_type,
   $aem_id                  = 'publish',
   $delete_repository_index = false,
-  $jmxremote_port          = '59185',
+  $jmxremote_port          = '59183',
   $jvm_mem_opts            = undef,
   $run_mode                = 'publish',
   $snapshotid              = $::snapshotid,


### PR DESCRIPTION
Part 2 to enable jmxremote and collectd for AEM.

Added feature to enable and configure JMXRemote and collectd for Author and Publish instances by default. 

Part 1: https://github.com/shinesolutions/aem-aws-stack-builder/pull/74

Regarding Issue https://github.com/shinesolutions/aem-aws-stack-provisioner/issues/51