### PR TITLE
Added fix to create the bash script to promote author

### DIFF
--- a/manifests/config_aem_tools.pp
+++ b/manifests/config_aem_tools.pp
@@ -62,6 +62,17 @@ class aem_curator::config_aem_tools (
     mode    => '0775',
     owner   => 'root',
     group   => 'root',
+  } -> file { "${base_dir}/aem-tools/promote-author-standby-to-primary.sh":
+    ensure  => present,
+    content => epp(
+      'aem_curator/aem-tools/promote-author-standby-to-primary.sh.epp', {
+        'base_dir'                       => $base_dir,
+        'aem_password_retrieval_command' => $aem_password_retrieval_command,
+      }
+    ),
+    mode    => '0775',
+    owner   => 'root',
+    group   => 'root',
   } -> file {"${base_dir}/aem-tools/crx-process-quited.sh":
     ensure => present,
     source => 'puppet:///modules/aem_curator/aem-tools/crx-process-quited.sh',


### PR DESCRIPTION
Added block to create the bash script to promot author standby to primary.

Regarding https://github.com/shinesolutions/puppet-aem-curator/issues/15