### PR TITLE
Should be after the previous JVM_OPTS="$JVM_OPTS line for Jmxremote_port

### DIFF
--- a/manifests/config_author_primary.pp
+++ b/manifests/config_author_primary.pp
@@ -81,7 +81,7 @@ class aem_curator::config_author_primary (
       ensure => present,
       path   => "${crx_quickstart_dir}/bin/start-env",
       line   => "JVM_OPTS=\"\$JVM_OPTS ${jvm_opts} \"",
-      after  => '^JVM_OPTS',
+      after  => '^JVM_OPTS=\"\$JVM_OPTS',
       notify => Service['aem-author'],
     }
   }

--- a/manifests/config_author_standby.pp
+++ b/manifests/config_author_standby.pp
@@ -80,7 +80,7 @@ class aem_curator::config_author_standby (
       ensure => present,
       path   => "${crx_quickstart_dir}/bin/start-env",
       line   => "JVM_OPTS=\"\$JVM_OPTS ${jvm_opts} \"",
-      after  => '^JVM_OPTS',
+      after  => '^JVM_OPTS=\"\$JVM_OPTS',
       notify => Service['aem-author'],
     }
   }

--- a/manifests/config_publish.pp
+++ b/manifests/config_publish.pp
@@ -100,7 +100,7 @@ class aem_curator::config_publish (
       ensure => present,
       path   => "${crx_quickstart_dir}/bin/start-env",
       line   => "JVM_OPTS=\"\$JVM_OPTS ${jvm_opts} \"",
-      after  => '^JVM_OPTS',
+      after  => '^JVM_OPTS=\"\$JVM_OPTS',
       notify => Service['aem-publish'],
     }
   }


### PR DESCRIPTION
Fix a bug where the file_line was not explicit in matching the correct lines.