### PR TITLE
Modify manifest action_deploy_artifact

### DIFF
--- a/manifests/action_deploy_artifact.pp
+++ b/manifests/action_deploy_artifact.pp
@@ -3,18 +3,33 @@ File {
 }
 
 class aem_curator::action_deploy_artifact (
-  $aem_id            = $::aem_id,
-  $aem_username      = $::aem_username,
-  $aem_password      = $::aem_password,
-  $package_source    = $::package_source,
-  $package_group     = $::package_group,
-  $package_name      = $::package_name,
-  $package_version   = $::package_version,
-  $package_replicate = $::package_replicate,
-  $package_activate  = $::package_activate,
-  $package_force     = $::package_force,
-  $path              = '/tmp/shinesolutions/aem-aws-stack-provisioner',
+  $aem_id                     = $::aem_id,
+  $aem_username               = $::aem_username,
+  $aem_password               = $::aem_password,
+  $package_source             = $::package_source,
+  $package_group              = $::package_group,
+  $package_name               = $::package_name,
+  $package_version            = $::package_version,
+  $package_replicate          = $::package_replicate,
+  $package_activate           = $::package_activate,
+  $package_force              = $::package_force,
+  $path                       = '/tmp/shinesolutions/aem-aws-stack-provisioner',
+  $retries_max_tries          = 60,
+  $retries_base_sleep_seconds = 5,
+  $retries_max_sleep_seconds  = 5,
 ) {
+
+  Aem_aem {
+    retries_max_tries          => $retries_max_tries,
+    retries_base_sleep_seconds => $retries_base_sleep_seconds,
+    retries_max_sleep_seconds  => $retries_max_sleep_seconds,
+  }
+
+  Aem_package {
+    retries_max_tries          => $retries_max_tries,
+    retries_base_sleep_seconds => $retries_base_sleep_seconds,
+    retries_max_sleep_seconds  => $retries_max_sleep_seconds,
+  }
 
   $_aem_id = pick(
     $aem_id,


### PR DESCRIPTION
Modify manifest action_deploy_artifact to make ruby-aem retry parameters configurable similar to manifest action_deploy_artifacts