### PR TITLE
Lock down inspec version to 2.2.78 #60

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - "2.1"
-  - "2.2"
   - "2.3"
   - "2.4"
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ### 1.1.3
+* Lock inspec version to 2.2.78 #60
+* Remove support for Ruby 2.1 & 2.2 due to dependency issues
 *
 
 ### 1.1.2

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "inspec", require: false
+gem "inspec", '2.2.78', require: false
 gem "puppet-lint", require: false
 gem "rake", require: false
 gem "r10k", require: false


### PR DESCRIPTION
Lock down inspec version to 2.2.78 #60

* Lock down inspec version to 2.2.78 #60
* Remove support for Ruby 2.1 & 2.2 due to dependency issues