### PR TITLE
Updated params for "Wait until login page is ready" to use user values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 0.10.7
-*
+* Updated parameters for "Wait until login page is ready" to consume parameters form shinesolutions/aem-aws-stack-provisioner during stack creation shinesolutions/aem-aws-stack-builder#184
 
 ### 0.10.6
 * Upgrade aem_resources to 2.3.1 for aem_user_alias support

--- a/manifests/config_author_primary.pp
+++ b/manifests/config_author_primary.pp
@@ -31,6 +31,9 @@ class aem_curator::config_author_primary (
   $crx_quickstart_dir,
   $enable_crxde,
   $enable_default_passwords,
+  $login_ready_base_sleep_seconds,
+  $login_ready_max_sleep_seconds,
+  $login_ready_max_tries,
   $puppet_conf_dir,
   $tmp_dir,
   $aem_base                   = undef,
@@ -135,9 +138,9 @@ class aem_curator::config_author_primary (
     enable => true,
   } -> aem_aem { "${aem_id}: Wait until login page is ready":
     ensure                     => login_page_is_ready,
-    retries_max_tries          => 120,
-    retries_base_sleep_seconds => 5,
-    retries_max_sleep_seconds  => 5,
+    retries_max_tries          => $login_ready_max_tries,
+    retries_base_sleep_seconds => $login_ready_base_sleep_seconds,
+    retries_max_sleep_seconds  => $login_ready_max_sleep_seconds,
     aem_id                     => $aem_id,
   } -> aem_curator::reconfig_aem{ "${aem_id}: Reconfigure AEM":
     aem_base                   => $aem_base,


### PR DESCRIPTION
* Updated parameters for "Wait until login page is ready" to consume parameters form shinesolutions/aem-aws-stack-provisioner during stack creation shinesolutions/aem-aws-stack-builder#184