### PR TITLE
Fixed logic error in config_saml manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.4.1
+* Fixed logic error in config_saml manifest
+
 ### 1.4.0
 * Add new AEM profile: aem65
 

--- a/manifests/config_saml.pp
+++ b/manifests/config_saml.pp
@@ -73,7 +73,6 @@ define aem_curator::config_saml (
       aem_username => $aem_username,
       aem_password => $aem_password,
       tmp_dir      => $tmp_dir,
-      require      => Aem_certificate[aem_certificate],
     }
 
     create_resources(


### PR DESCRIPTION
If the option enable_saml_certificate_upload is set to false the stack provisioning will fail. This pr solution should solve the problem.