### PR TITLE
Add file copy to whitelist aem-password-bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add file copy to whitelist aem-password-bundle during AEM Startup shinesolutions/aem-aws-stack-builder#260
+
+
 ## [1.12.0] - 2019-02-28
 ### Fixed
 - Fix aem-healthcheck package clean up due to aem::crx::package installing via install dir and not package manager

--- a/files/crx-quickstart/install/org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment-passwordreset.config
+++ b/files/crx-quickstart/install/org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment-passwordreset.config
@@ -1,0 +1,2 @@
+whitelist.name="passwordreset"
+whitelist.bundles=["com.shinesolutions.aem.passwordreset"]

--- a/manifests/config_author_primary.pp
+++ b/manifests/config_author_primary.pp
@@ -147,6 +147,12 @@ class aem_curator::config_author_primary (
   } -> archive { "${crx_quickstart_dir}/install/aem-password-reset-content-${aem_password_reset_version}.zip":
     ensure => present,
     source => $aem_password_reset_source,
+  } -> file {"${crx_quickstart_dir}/install/org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment-passwordreset.config":
+    ensure => present,
+    source => 'puppet:///modules/aem_curator/crx-quickstart/install/org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment-passwordreset.config',
+    mode   => '0775',
+    owner  => "aem-${aem_id}",
+    group  => "aem-${aem_id}",
   } -> aem_resources::puppet_aem_resources_set_config { 'Set puppet-aem-resources config file for author-primary':
     conf_dir => $puppet_conf_dir,
     timeout  => $author_timeout,
@@ -315,6 +321,8 @@ class aem_curator::config_author_primary (
     retries_base_sleep_seconds => $login_ready_base_sleep_seconds,
     retries_max_sleep_seconds  => $login_ready_max_sleep_seconds,
     aem_id                     => $aem_id,
+  } -> exec { "${aem_id}: Remove file org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment-passwordreset.config":
+    command => "rm -f ${crx_quickstart_dir}/install/org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment-passwordreset.config",
   } -> aem_package { "${aem_id}: Remove password reset package":
     ensure  => absent,
     name    => 'aem-password-reset-content',

--- a/manifests/config_publish.pp
+++ b/manifests/config_publish.pp
@@ -137,6 +137,12 @@ class aem_curator::config_publish (
   } -> archive { "${crx_quickstart_dir}/install/aem-password-reset-content-${aem_password_reset_version}.zip":
     ensure => present,
     source => $aem_password_reset_source,
+  } -> file {"${crx_quickstart_dir}/install/org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment-passwordreset.config":
+    ensure => present,
+    source => 'puppet:///modules/aem_curator/crx-quickstart/install/org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment-passwordreset.config',
+    mode   => '0775',
+    owner  => "aem-${aem_id}",
+    group  => "aem-${aem_id}",
   } -> aem_resources::puppet_aem_resources_set_config { 'Set puppet-aem-resources config file for publish':
     conf_dir => $puppet_conf_dir,
     timeout  => $publish_timeout,
@@ -269,6 +275,8 @@ class aem_curator::config_publish (
     retries_base_sleep_seconds => $login_ready_base_sleep_seconds,
     retries_max_sleep_seconds  => $login_ready_max_sleep_seconds,
     aem_id                     => $aem_id,
+  } -> exec { "${aem_id}: Remove file org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment-passwordreset.config":
+    command => "rm -f ${crx_quickstart_dir}/install/org.apache.sling.jcr.base.internal.LoginAdminWhitelist.fragment-passwordreset.config",
   } -> aem_package { "${aem_id}: Remove password reset package":
     ensure  => absent,
     name    => 'aem-password-reset-content',


### PR DESCRIPTION
Add file copy to whitelist aem-password-bundle for the usage of the loginAdministrative method during AEM Startup shinesolutions/aem-aws-stack-builder#260