### PR TITLE
Removing system dir from dispatcher's web root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Upgrade aem_resources to 3.9.0
-- Remove system dir from docroot_dir in dispatchers
+- Remove system dir from docroot_dir in flush dispatcher cache
 
 ## [1.19.0] - 2019-04-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Upgrade aem_resources to 3.9.0
+- Remove system dir from docroot_dir in dispatchers
 
 ## [1.19.0] - 2019-04-01
 ### Added

--- a/manifests/action_flush_dispatcher_cache.pp
+++ b/manifests/action_flush_dispatcher_cache.pp
@@ -9,7 +9,6 @@ class aem_curator::action_flush_dispatcher_cache (
       "${docroot_dir}/etc",
       "${docroot_dir}/home",
       "${docroot_dir}/libs",
-      "${docroot_dir}/system",
       "${docroot_dir}/tmp",
       "${docroot_dir}/var"
     ]:


### PR DESCRIPTION
flush_dispatcher action creates the system folder part of the default structure in docroot_dir.
This avoids the healthcheck api to redirect to author/publisher. Hence removing the "${docroot_dir}/system" folder from creation