### PR TITLE
Changes related to shinesolutions/puppet-aem-curator#134 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added proxy_enabled parameter for collectd configuration #134
+
+### Changed
+- Changed condition from proxy_host to proxy_anabled #134 
+
 
 ## [2.7.0] - 2019-07-31
 ### Added

--- a/manifests/config_collectd.pp
+++ b/manifests/config_collectd.pp
@@ -12,6 +12,7 @@
 #
 class aem_curator::config_collectd (
   $proxy_protocol,
+  $proxy_enabled,
   $proxy_host,
   $proxy_port,
   $component,
@@ -20,7 +21,7 @@ class aem_curator::config_collectd (
   $ec2_id,
 ) {
 
-  if $proxy_host != '' {
+  if $proxy_enabled = 'true' {
     file_line { 'Set the collectd cloudwatch proxy_server_name':
       path   => '/opt/collectd-cloudwatch/src/cloudwatch/config/plugin.conf',
       line   => "proxy_server_name = \"${proxy_protocol}://${proxy_host}\"",

--- a/manifests/config_collectd.pp
+++ b/manifests/config_collectd.pp
@@ -21,7 +21,7 @@ class aem_curator::config_collectd (
   $ec2_id,
 ) {
 
-  if $proxy_enabled = 'true' {
+  if $proxy_enabled == true {
     file_line { 'Set the collectd cloudwatch proxy_server_name':
       path   => '/opt/collectd-cloudwatch/src/cloudwatch/config/plugin.conf',
       line   => "proxy_server_name = \"${proxy_protocol}://${proxy_host}\"",


### PR DESCRIPTION
proxy_enable had been added to the config_collectd.pp and change value to true .
this is due to TT config_collectd always configures proxy #134 related to shinesolutions/puppet-aem-curator#134 