### PR TITLE
Add installation of package aem-healthcheck-content #181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add installation of package aem-healthcheck-content to the provisioning process #181
+
 ## [2.8.0] - 2019-08-15
 ### Added
 - Added proxy_enabled parameter for collectd configuration [#134]


### PR DESCRIPTION
Add installation of package aem-healthcheck-content to the provisioning 
process #181

This PR changes the provisioning process as follows:

* Remove any packages in `${crx_quickstart_dir}/install/aem-healthcheck-content-*.zip`... but only if the array `$list_clean_directories` doesn't include the string `install` ... This is  because we don't need to remove the healthcheck content packages if the install directory got wiped by the process to wipe some certain dirs a step before this one.

* Place the aem-healthcheck-content package to the `install` dir using the class `aem_curator::install_aem_healthcheck`, after AEM was started and after the reconfiguration. But only when the reconfiguration flag `enable_aem_reconfiguratiton_clean_directories` is set to false. 

This is due to the fact that the flag `enable_aem_reconfiguratiton_clean_directories` cleans the directory `install` during reconfiguration. Since the reconfiguration cleans this dir it is in the responisbility of the reconfiguration to install the aem-healthcheck package.