### PR TITLE
Add installation of package aem-healthcheck-content #181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add installation of package aem-healthcheck-content to the provisioning process #181
+
 ## [2.8.0] - 2019-08-15
 ### Added
 - Added proxy_enabled parameter for collectd configuration [#134]

--- a/manifests/config_author_primary.pp
+++ b/manifests/config_author_primary.pp
@@ -36,7 +36,7 @@ class aem_curator::config_author_primary (
   $login_ready_max_tries,
   $puppet_conf_dir,
   $tmp_dir,
-  $aem_base                                              = undef,
+  $aem_base                                              = '/opt',
   $aem_healthcheck_source                                = undef,
   $aem_healthcheck_version                               = undef,
   $aem_id                                                = 'author',
@@ -44,6 +44,7 @@ class aem_curator::config_author_primary (
   $aem_keystore_path                                     = undef,
   $data_volume_mount_point                               = undef,
   $enable_aem_reconfiguration                            = false,
+  $enable_aem_reconfiguratiton_clean_directories         = false,
   $enable_truststore_migration                           = false,
   $enable_truststore_removal                             = false,
   $enable_authorizable_keystore_creation                 = false,
@@ -75,6 +76,13 @@ class aem_curator::config_author_primary (
   if !defined(File[$tmp_dir]) {
     file { $tmp_dir:
       ensure => directory,
+    }
+  }
+
+  if !defined(File["${tmp_dir}/${aem_id}"]) {
+    file { "${tmp_dir}/${aem_id}":
+      ensure => directory,
+      mode   => '0700',
     }
   }
 
@@ -150,6 +158,41 @@ class aem_curator::config_author_primary (
     }
   }
 
+ #
+ # If reconfiguration is enabled & clean directories for reconfiguration
+ # is enabled than we don't install AEM Healthcheck because it's already
+ # done during the reconfiguration process. Otherwise install aem healthcheck
+ # apart from the reconfiguration process.
+ #
+ unless $enable_aem_reconfiguratiton_clean_directories {
+   #
+   # remove any aem-healthcheck-content package from the install directory
+   # If install dir isn't cleaned up a step before per default
+   #
+   if !('install' in $list_clean_directories) {
+    exec { "${aem_id}: remove ${crx_quickstart_dir}/install/aem-healthcheck-content-*.zip":
+      command => "rm -fr ${crx_quickstart_dir}/install/aem-healthcheck-content-*.zip",
+      before  => [
+        Service['aem-author']
+      ],
+     }
+   }
+
+   aem_curator::install_aem_healthcheck {"${aem_id}: Install AEM Healthcheck":
+     aem_base                => $aem_base,
+     aem_healthcheck_source  => $aem_healthcheck_source,
+     aem_healthcheck_version => $aem_healthcheck_version,
+     aem_id                  => $aem_id,
+     tmp_dir                 => $tmp_dir,
+     require                 => [
+                                  Service['aem-author'],
+                                ],
+     before                  => [
+                                  Aem_aem["${aem_id}: Wait until login page is ready"],
+                                ]
+   }
+ }
+
   file { "${crx_quickstart_dir}/install/":
     ensure => directory,
     mode   => '0775',
@@ -211,6 +254,7 @@ class aem_curator::config_author_primary (
     crx_quickstart_dir         => $crx_quickstart_dir,
     data_volume_mount_point    => $data_volume_mount_point,
     enable_aem_reconfiguration => $enable_aem_reconfiguration,
+    enable_clean_directories   => $enable_aem_reconfiguratiton_clean_directories,
     enable_create_system_users => $enable_create_system_users,
     enable_truststore_removal  => $enable_truststore_removal,
     run_mode                   => $run_mode,

--- a/manifests/config_author_primary.pp
+++ b/manifests/config_author_primary.pp
@@ -158,40 +158,40 @@ class aem_curator::config_author_primary (
     }
   }
 
- #
- # If reconfiguration is enabled & clean directories for reconfiguration
- # is enabled than we don't install AEM Healthcheck because it's already
- # done during the reconfiguration process. Otherwise install aem healthcheck
- # apart from the reconfiguration process.
- #
- unless $enable_aem_reconfiguratiton_clean_directories {
-   #
-   # remove any aem-healthcheck-content package from the install directory
-   # If install dir isn't cleaned up a step before per default
-   #
-   if !('install' in $list_clean_directories) {
-    exec { "${aem_id}: remove ${crx_quickstart_dir}/install/aem-healthcheck-content-*.zip":
-      command => "rm -fr ${crx_quickstart_dir}/install/aem-healthcheck-content-*.zip",
-      before  => [
-        Service['aem-author']
+  #
+  # If reconfiguration is enabled & clean directories for reconfiguration
+  # is enabled than we don't install AEM Healthcheck because it's already
+  # done during the reconfiguration process. Otherwise install aem healthcheck
+  # apart from the reconfiguration process.
+  #
+  unless $enable_aem_reconfiguratiton_clean_directories {
+  #
+  # remove any aem-healthcheck-content package from the install directory
+  # If install dir isn't cleaned up a step before per default
+  #
+  if !('install' in $list_clean_directories) {
+  exec { "${aem_id}: remove ${crx_quickstart_dir}/install/aem-healthcheck-content-*.zip":
+    command => "rm -fr ${crx_quickstart_dir}/install/aem-healthcheck-content-*.zip",
+    before  => [
+      Service['aem-author']
       ],
-     }
-   }
+    }
+  }
 
-   aem_curator::install_aem_healthcheck {"${aem_id}: Install AEM Healthcheck":
-     aem_base                => $aem_base,
-     aem_healthcheck_source  => $aem_healthcheck_source,
-     aem_healthcheck_version => $aem_healthcheck_version,
-     aem_id                  => $aem_id,
-     tmp_dir                 => $tmp_dir,
-     require                 => [
-                                  Service['aem-author'],
-                                ],
-     before                  => [
-                                  Aem_aem["${aem_id}: Wait until login page is ready"],
-                                ]
-   }
- }
+  aem_curator::install_aem_healthcheck {"${aem_id}: Install AEM Healthcheck":
+    aem_base                => $aem_base,
+    aem_healthcheck_source  => $aem_healthcheck_source,
+    aem_healthcheck_version => $aem_healthcheck_version,
+    aem_id                  => $aem_id,
+    tmp_dir                 => $tmp_dir,
+    require                 => [
+                                Service['aem-author'],
+                              ],
+    before                  => [
+                                Aem_aem["${aem_id}: Wait until login page is ready"],
+                              ]
+    }
+  }
 
   file { "${crx_quickstart_dir}/install/":
     ensure => directory,

--- a/manifests/config_publish.pp
+++ b/manifests/config_publish.pp
@@ -150,40 +150,40 @@ class aem_curator::config_publish (
     }
   }
 
- #
- # If reconfiguration is enabled & clean directories for reconfiguration
- # is enabled than we don't install AEM Healthcheck because it's already
- # done during the reconfiguration process. Otherwise install aem healthcheck
- # apart from the reconfiguration process.
- #
- unless $enable_aem_reconfiguratiton_clean_directories {
-   #
-   # remove any aem-healthcheck-content package from the install directory
-   # If install dir isn't cleaned up a step before per default
-   #
-   if !('install' in $list_clean_directories) {
-    exec { "${aem_id}: remove ${crx_quickstart_dir}/install/aem-healthcheck-content-*.zip":
-      command => "rm -fr ${crx_quickstart_dir}/install/aem-healthcheck-content-*.zip",
-      before  => [
-        Service['aem-publish']
+  #
+  # If reconfiguration is enabled & clean directories for reconfiguration
+  # is enabled than we don't install AEM Healthcheck because it's already
+  # done during the reconfiguration process. Otherwise install aem healthcheck
+  # apart from the reconfiguration process.
+  #
+  unless $enable_aem_reconfiguratiton_clean_directories {
+  #
+  # remove any aem-healthcheck-content package from the install directory
+  # If install dir isn't cleaned up a step before per default
+  #
+  if !('install' in $list_clean_directories) {
+  exec { "${aem_id}: remove ${crx_quickstart_dir}/install/aem-healthcheck-content-*.zip":
+    command => "rm -fr ${crx_quickstart_dir}/install/aem-healthcheck-content-*.zip",
+    before  => [
+      Service['aem-publish']
       ],
-     }
-   }
+    }
+  }
 
-   aem_curator::install_aem_healthcheck {"${aem_id}: Install AEM Healthcheck":
-     aem_base                => $aem_base,
-     aem_healthcheck_source  => $aem_healthcheck_source,
-     aem_healthcheck_version => $aem_healthcheck_version,
-     aem_id                  => $aem_id,
-     tmp_dir                 => $tmp_dir,
-     require                 => [
-                                  Service['aem-publish'],
-                                ],
-     before                  => [
-                                  Aem_aem["${aem_id}: Wait until login page is ready"],
-                                ]
-   }
- }
+  aem_curator::install_aem_healthcheck {"${aem_id}: Install AEM Healthcheck":
+    aem_base                => $aem_base,
+    aem_healthcheck_source  => $aem_healthcheck_source,
+    aem_healthcheck_version => $aem_healthcheck_version,
+    aem_id                  => $aem_id,
+    tmp_dir                 => $tmp_dir,
+    require                 => [
+                                Service['aem-publish'],
+                              ],
+    before                  => [
+                                Aem_aem["${aem_id}: Wait until login page is ready"],
+                              ]
+    }
+  }
 
   file { "${crx_quickstart_dir}/install/":
     ensure => directory,

--- a/manifests/config_publish.pp
+++ b/manifests/config_publish.pp
@@ -40,33 +40,41 @@ class aem_curator::config_publish (
   $publish_timeout,
   $puppet_conf_dir,
   $tmp_dir,
-  $aem_base                    = undef,
-  $aem_healthcheck_source      = undef,
-  $aem_healthcheck_version     = undef,
-  $aem_id                      = 'publish',
-  $aem_ssl_keystore_password   = undef,
-  $aem_keystore_path           = undef,
-  $cert_base_url               = undef,
-  $data_volume_mount_point     = undef,
-  $delete_repository_index     = false,
-  $enable_aem_reconfiguration  = false,
-  $enable_post_start_sleep     = false,
-  $enable_truststore_creation  = false,
-  $enable_truststore_migration = false,
-  $enable_truststore_removal   = false,
-  $enable_create_system_users  = undef,
-  $post_start_sleep_seconds    = '120',
-  $publish_ssl_port            = undef,
-  $jmxremote_port              = '59183',
-  $jvm_mem_opts                = undef,
-  $jvm_opts                    = undef,
-  $run_mode                    = 'publish',
-  $truststore_password         = undef,
+  $aem_base                                      = '/opt',
+  $aem_healthcheck_source                        = undef,
+  $aem_healthcheck_version                       = undef,
+  $aem_id                                        = 'publish',
+  $aem_ssl_keystore_password                     = undef,
+  $aem_keystore_path                             = undef,
+  $cert_base_url                                 = undef,
+  $data_volume_mount_point                       = undef,
+  $delete_repository_index                       = false,
+  $enable_aem_reconfiguration                    = false,
+  $enable_aem_reconfiguratiton_clean_directories = false,
+  $enable_post_start_sleep                       = false,
+  $enable_truststore_creation                    = false,
+  $enable_truststore_migration                   = false,
+  $enable_truststore_removal                     = false,
+  $enable_create_system_users                    = undef,
+  $post_start_sleep_seconds                      = '120',
+  $publish_ssl_port                              = undef,
+  $jmxremote_port                                = '59183',
+  $jvm_mem_opts                                  = undef,
+  $jvm_opts                                      = undef,
+  $run_mode                                      = 'publish',
+  $truststore_password                           = undef,
 ) {
 
   if !defined(File[$tmp_dir]) {
     file { $tmp_dir:
       ensure => directory,
+    }
+  }
+
+  if !defined(File["${tmp_dir}/${aem_id}"]) {
+    file { "${tmp_dir}/${aem_id}":
+      ensure => directory,
+      mode   => '0700',
     }
   }
 
@@ -142,6 +150,41 @@ class aem_curator::config_publish (
     }
   }
 
+ #
+ # If reconfiguration is enabled & clean directories for reconfiguration
+ # is enabled than we don't install AEM Healthcheck because it's already
+ # done during the reconfiguration process. Otherwise install aem healthcheck
+ # apart from the reconfiguration process.
+ #
+ unless $enable_aem_reconfiguratiton_clean_directories {
+   #
+   # remove any aem-healthcheck-content package from the install directory
+   # If install dir isn't cleaned up a step before per default
+   #
+   if !('install' in $list_clean_directories) {
+    exec { "${aem_id}: remove ${crx_quickstart_dir}/install/aem-healthcheck-content-*.zip":
+      command => "rm -fr ${crx_quickstart_dir}/install/aem-healthcheck-content-*.zip",
+      before  => [
+        Service['aem-publish']
+      ],
+     }
+   }
+
+   aem_curator::install_aem_healthcheck {"${aem_id}: Install AEM Healthcheck":
+     aem_base                => $aem_base,
+     aem_healthcheck_source  => $aem_healthcheck_source,
+     aem_healthcheck_version => $aem_healthcheck_version,
+     aem_id                  => $aem_id,
+     tmp_dir                 => $tmp_dir,
+     require                 => [
+                                  Service['aem-publish'],
+                                ],
+     before                  => [
+                                  Aem_aem["${aem_id}: Wait until login page is ready"],
+                                ]
+   }
+ }
+
   file { "${crx_quickstart_dir}/install/":
     ensure => directory,
     mode   => '0775',
@@ -180,7 +223,7 @@ class aem_curator::config_publish (
     retries_base_sleep_seconds => $login_ready_base_sleep_seconds,
     retries_max_sleep_seconds  => $login_ready_max_sleep_seconds,
     aem_id                     => $aem_id,
-  } -> aem_aem { "${aem_id}: Wait until CRX Package Manager is ready":
+  } -> aem_aem { "${aem_id}: Wait until CRX Package Manager is ready" :
     ensure                     => aem_package_manager_is_ready,
     retries_max_tries          => $login_ready_max_tries,
     retries_base_sleep_seconds => $login_ready_base_sleep_seconds,
@@ -195,6 +238,7 @@ class aem_curator::config_publish (
     aem_keystore_path          => $aem_keystore_path,
     crx_quickstart_dir         => $crx_quickstart_dir,
     enable_aem_reconfiguration => $enable_aem_reconfiguration,
+    enable_clean_directories   => $enable_aem_reconfiguratiton_clean_directories,
     enable_truststore_removal  => $enable_truststore_removal,
     aem_ssl_port               => $publish_ssl_port,
     aem_system_users           => $aem_system_users,


### PR DESCRIPTION
Add installation of package aem-healthcheck-content to the provisioning
process #181

This PR changes the provisioning process as follows:

if `enable_aem_reconfiguratiton_clean_directories` is set to false  it will ....

* Remove any packages in `${crx_quickstart_dir}/install/aem-healthcheck-content-*.zip`... but only if the array `$list_clean_directories` doesn't include the string `install` ... This is because we don't need to remove the healthcheck content packages if the install directory got wiped by the process to wipe some certain dirs a step before this one.

* Place the aem-healthcheck-content package to the `install` dir using the class `aem_curator::install_aem_healthcheck`, after AEM was started but before the reconfiguration

This is due to the fact that the flag `enable_aem_reconfiguratiton_clean_directories` cleans the directory `install` during reconfiguration. Since the reconfiguration cleans this dir it is in the responisbility of the reconfiguration to install the aem-healthcheck package.