### PR TITLE
reconfigure aem agent configuration #149 #150

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added new manifest to configure AEM agents [#149] [#150]
+- Added new parameter `enable_remove_all_agents` to enable removal of all AEM agents when configuring author-primary & publish [#149] [#150]
 
 ### Removed
 - Removed all agents configurations from the config author-primary & publish manifest [#149] [#150]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added new manifest to configure AEM agents [#149] [#150]
 - Added new parameter `enable_remove_all_agents` to enable removal of all AEM agents when configuring author-primary & publish [#149] [#150]
+- Added new parameter `enable_create_flush_agents` to enable creation of flush agent when configuring publish [#149] [#150]
 
 ### Removed
 - Removed all agents configurations from the config author-primary & publish manifest [#149] [#150]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added new manifest to configure AEM agents #149 #150
+- Added new manifest to configure AEM agents [#149] [#150]
 
 ### Removed
-- Removed all agents configurations from the config author-primary & publish manifest #149 #150
+- Removed all agents configurations from the config author-primary & publish manifest [#149] [#150]
 
 ## [3.0.1] - 2019-10-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added new manifest to configure AEM agents #149 #150
+
+### Removed
+- Removed all agents configurations from the config author-primary & publish manifest #149 #150
+
 ## [3.0.1] - 2019-10-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new manifest to configure AEM agents [#149] [#150]
 - Added new parameter `enable_remove_all_agents` to enable removal of all AEM agents when configuring author-primary & publish [#149] [#150]
 - Added new parameter `enable_create_flush_agents` to enable creation of flush agent when configuring publish [#149] [#150]
+- Added new parameter `enable_create_outbox_replication_agents` to enable creation of outbox replication agent when configuring publish [#149] [#150]
 
 ### Removed
 - Removed all agents configurations from the config author-primary & publish manifest [#149] [#150]

--- a/manifests/config_aem_agents.pp
+++ b/manifests/config_aem_agents.pp
@@ -1,0 +1,115 @@
+#== Define: aem_curator::config_aem_agents
+# This manifest helps you to configure AEM agents on AEM.
+#
+# Via a control flag you can enable the removal of all agents on AEM
+# or the creation of certain agents.
+#
+# === Parameters
+# [*aem_id*]
+#   String to define the aem id.
+#   Supported values are aem, author or publish.
+#
+# [*dispatcher_host_url*]
+#   String to define the dispatcher url.
+#   Per default we are assuming that the dispatcher is using HTTPS via port 443.
+#
+# [*dispatcher_id*]
+#   String to define the dispatcher id for creating the flush agent or outbox agents on AEM.
+#
+# [*enable_create_flush_agents*]
+#   Boolean to run the process of creating the flush agents on AEM.
+#
+# [*enable_create_outbox_replication_agents*]
+#   Boolean to run the process of creating the outbox replication agents on AEM.
+#
+# [*enable_remove_all_agents*]
+#   Boolean to run the process of removing all existing agents on AEM.
+#
+# [*log_level*]
+# Sring tp define th log level for the agents.
+# Default is info.
+# Allowed values are info, error, debug.
+#
+# [*run_mode*]
+#  String to define the run mode for creating the AEM Agents.
+#   Supported values are author or publish.
+#
+# [*replication_agent_user_id*]
+#  String to define user id of the replication agent.
+#  Default value is `replicator.`
+#
+# === Copyright
+#
+# Copyright © 2017 Shine Solutions Group, unless otherwise noted.
+#
+
+define aem_curator::config_aem_agents (
+  $aem_id                                  = undef,
+  $dispatcher_id                           = undef,
+  $dispatcher_host_url                     = undef,
+  $enable_create_flush_agents              = false,
+  $enable_create_outbox_replication_agents = false,
+  $enable_remove_all_agents                = false,
+  $log_level                               = 'info',
+  $replication_agent_user_id               = 'replicator',
+  $run_mode                                = undef,
+) {
+  # Validate booleans
+  validate_bool($enable_create_flush_agents)
+  validate_bool($enable_create_outbox_replication_agents)
+  validate_bool($enable_remove_all_agents)
+
+  # Validate aem_id
+  validate_string($aem_id)
+  # Validate run mode
+  validate_string($run_mode)
+
+  if $enable_remove_all_agents {
+    aem_aem { "${aem_id}: Remove all agents":
+        ensure   => all_agents_removed,
+        run_mode => $run_mode,
+        aem_id   => $aem_id,
+      }
+  }
+
+  if $enable_create_flush_agents {
+
+    # Validate Strings
+    validate_string($dispatcher_id)
+    validate_string($dispatcher_host_url)
+    validate_string($log_level)
+
+    aem_flush_agent { "${aem_id}: Create flush agent for ${run_mode}-dispatcher ${dispatcher_id}":
+      ensure        => present,
+      name          => "flushAgent-${dispatcher_id}",
+      run_mode      => $run_mode,
+      title         => "Flush agent for ${run_mode}-dispatcher ${dispatcher_id}",
+      description   => "Flush agent for ${run_mode}-dispatcher ${dispatcher_id}",
+      dest_base_url => "https://${dispatcher_host_url}:443",
+      log_level     => $log_level,
+      retry_delay   => 60000,
+      force         => true,
+      aem_id        => $aem_id,
+    }
+  }
+
+  if $enable_create_outbox_replication_agents {
+
+    # Validate Strings
+    validate_string($dispatcher_id)
+    validate_string($log_level)
+    validate_string($replication_agent_user_id)
+
+    aem_outbox_replication_agent { "${aem_id}: Create outbox replication agent for ${run_mode}-dispatcher ${dispatcher_id}":
+      ensure      => present,
+      name        => 'outbox',
+      run_mode    => $run_mode,
+      title       => "Outbox replication agent ${run_mode}-dispatcher ${dispatcher_id}",
+      description => "Outbox replication agent for ${run_mode}-dispatcher ${dispatcher_id}",
+      user_id     => $replication_agent_user_id,
+      log_level   => $log_level,
+      force       => true,
+      aem_id      => $aem_id,
+    }
+  }
+}

--- a/manifests/config_author_primary.pp
+++ b/manifests/config_author_primary.pp
@@ -375,10 +375,10 @@ class aem_curator::config_author_primary (
     retries_max_sleep_seconds  => $login_ready_max_sleep_seconds,
     tags                       => 'deep',
     aem_id                     => $aem_id,
-  } -> aem_aem { "${aem_id}: Remove all agents":
-    ensure   => all_agents_removed,
-    run_mode => 'author',
-    aem_id   => $aem_id,
+  } -> aem_curator::config_aem_agents { "${aem_id}: Remove all agents":
+    run_mode                 => 'author',
+    aem_id                   => $aem_id,
+    enable_remove_all_agents => true,
   } -> aem_aem { "${aem_id}: Wait until login page is ready after removing all agents":
     ensure                     => login_page_is_ready,
     retries_max_tries          => $login_ready_max_tries,

--- a/manifests/config_author_primary.pp
+++ b/manifests/config_author_primary.pp
@@ -52,6 +52,7 @@ class aem_curator::config_author_primary (
   $enable_post_start_sleep                               = false,
   $enable_saml                                           = false,
   $enable_truststore_creation                            = false,
+  $enable_remove_all_agents                              = false,
   $author_ssl_port                                       = undef,
   $aem_version                                           = '6.2',
   $certificate_arn                                       = undef,
@@ -378,7 +379,7 @@ class aem_curator::config_author_primary (
   } -> aem_curator::config_aem_agents { "${aem_id}: Remove all agents":
     run_mode                 => 'author',
     aem_id                   => $aem_id,
-    enable_remove_all_agents => true,
+    enable_remove_all_agents => $enable_remove_all_agents,
   } -> aem_aem { "${aem_id}: Wait until login page is ready after removing all agents":
     ensure                     => login_page_is_ready,
     retries_max_tries          => $login_ready_max_tries,

--- a/manifests/config_publish.pp
+++ b/manifests/config_publish.pp
@@ -54,6 +54,7 @@ class aem_curator::config_publish (
   $enable_aem_reconfiguration                    = false,
   $enable_aem_reconfiguratiton_clean_directories = false,
   $enable_post_start_sleep                       = false,
+  $enable_remove_all_agents                      = false,
   $enable_truststore_creation                    = false,
   $enable_truststore_migration                   = false,
   $enable_truststore_removal                     = false,
@@ -366,7 +367,7 @@ class aem_curator::config_publish (
   } -> aem_curator::config_aem_agents { "${aem_id}: Remove all agents":
     run_mode                 => 'publish',
     aem_id                   => $aem_id,
-    enable_remove_all_agents => true,
+    enable_remove_all_agents => $enable_remove_all_agents,
   } -> aem_aem { "${aem_id}: Wait until login page is ready after removing all agents":
     ensure                     => login_page_is_ready,
     retries_max_tries          => $login_ready_max_tries,

--- a/manifests/config_publish.pp
+++ b/manifests/config_publish.pp
@@ -54,6 +54,7 @@ class aem_curator::config_publish (
   $enable_aem_reconfiguration                    = false,
   $enable_aem_reconfiguratiton_clean_directories = false,
   $enable_create_flush_agents                    = false,
+  $enable_create_outbox_replication_agents       = false,
   $enable_post_start_sleep                       = false,
   $enable_remove_all_agents                      = false,
   $enable_truststore_creation                    = false,
@@ -451,7 +452,7 @@ class aem_curator::config_publish (
   } -> aem_curator::config_aem_agents { "${aem_id}: Create outbox replication agent":
     run_mode                                => 'publish',
     aem_id                                  => $aem_id,
-    enable_create_outbox_replication_agents => true,
+    enable_create_outbox_replication_agents => $enable_create_outbox_replication_agents,
     log_level                               => 'info',
     dispatcher_id                           => $publish_dispatcher_id,
     replication_agent_user_id               => 'replicator'

--- a/manifests/config_publish.pp
+++ b/manifests/config_publish.pp
@@ -363,10 +363,10 @@ class aem_curator::config_publish (
     retries_max_sleep_seconds  => $login_ready_max_sleep_seconds,
     tags                       => 'deep',
     aem_id                     => $aem_id,
-  } -> aem_aem { "${aem_id}: Remove all agents":
-    ensure   => all_agents_removed,
-    run_mode => 'publish',
-    aem_id   => $aem_id,
+  } -> aem_curator::config_aem_agents { "${aem_id}: Remove all agents":
+    run_mode                 => 'publish',
+    aem_id                   => $aem_id,
+    enable_remove_all_agents => true,
   } -> aem_aem { "${aem_id}: Wait until login page is ready after removing all agents":
     ensure                     => login_page_is_ready,
     retries_max_tries          => $login_ready_max_tries,
@@ -426,17 +426,13 @@ class aem_curator::config_publish (
     retries_max_sleep_seconds  => $login_ready_max_sleep_seconds,
     tags                       => 'deep',
     aem_id                     => $aem_id,
-  } -> aem_flush_agent { "${aem_id}: Create flush agent":
-    ensure        => present,
-    name          => "flushAgent-${publish_dispatcher_id}",
-    run_mode      => 'publish',
-    title         => "Flush agent for publish-dispatcher ${publish_dispatcher_id}",
-    description   => "Flush agent for publish-dispatcher ${publish_dispatcher_id}",
-    dest_base_url => "https://${publish_dispatcher_host}:443",
-    log_level     => 'info',
-    retry_delay   => 60000,
-    force         => true,
-    aem_id        => $aem_id,
+  } -> aem_curator::config_aem_agents { "${aem_id}: Create flush agent":
+    run_mode                   => 'publish',
+    aem_id                     => $aem_id,
+    enable_create_flush_agents => true,
+    log_level                  => 'info',
+    dispatcher_id              => $publish_dispatcher_id,
+    dispatcher_host_url        => $publish_dispatcher_host,
   } -> aem_aem { "${aem_id}: Wait until login page is ready after creating flush agent":
     ensure                     => login_page_is_ready,
     retries_max_tries          => $login_ready_max_tries,
@@ -450,16 +446,13 @@ class aem_curator::config_publish (
     retries_max_sleep_seconds  => $login_ready_max_sleep_seconds,
     tags                       => 'deep',
     aem_id                     => $aem_id,
-  } -> aem_outbox_replication_agent { "${aem_id}: Create outbox replication agent":
-    ensure      => present,
-    name        => 'outbox',
-    run_mode    => 'publish',
-    title       => "Outbox replication agent for publish-dispatcher ${publish_dispatcher_id}",
-    description => "Outbox replication agent for publish-dispatcher ${publish_dispatcher_id}",
-    user_id     => 'replicator',
-    log_level   => 'info',
-    force       => true,
-    aem_id      => $aem_id,
+  } -> aem_curator::config_aem_agents { "${aem_id}: Create outbox replication agent":
+    run_mode                                => 'publish',
+    aem_id                                  => $aem_id,
+    enable_create_outbox_replication_agents => true,
+    log_level                               => 'info',
+    dispatcher_id                           => $publish_dispatcher_id,
+    replication_agent_user_id               => 'replicator'
   } -> aem_aem { "${aem_id}: Wait until login page is ready after creating outbox replication agent":
     ensure                     => login_page_is_ready,
     retries_max_tries          => $login_ready_max_tries,

--- a/manifests/config_publish.pp
+++ b/manifests/config_publish.pp
@@ -53,6 +53,7 @@ class aem_curator::config_publish (
   $delete_repository_index                       = false,
   $enable_aem_reconfiguration                    = false,
   $enable_aem_reconfiguratiton_clean_directories = false,
+  $enable_create_flush_agents                    = false,
   $enable_post_start_sleep                       = false,
   $enable_remove_all_agents                      = false,
   $enable_truststore_creation                    = false,
@@ -430,7 +431,7 @@ class aem_curator::config_publish (
   } -> aem_curator::config_aem_agents { "${aem_id}: Create flush agent":
     run_mode                   => 'publish',
     aem_id                     => $aem_id,
-    enable_create_flush_agents => true,
+    enable_create_flush_agents => $enable_create_flush_agents,
     log_level                  => 'info',
     dispatcher_id              => $publish_dispatcher_id,
     dispatcher_host_url        => $publish_dispatcher_host,


### PR DESCRIPTION
reconfigure aem agent configuration #149 #150

This PR adds a new manifest to manager all AEM agents configuration we are usually doing within config_author_primary & config_publish. Each agent activity can be triggered via an enable flag. This allows to run the configuration manifest without updating/modifying the AEM agents. 

It further changes the default behaviour of forcing the removal of all agents on author & publish and the creation of the dispatcher flush & replication agent on publish. This is now disabled per default and needs explicitly be enabled via the new introduced parameters

`enable_remove_all_agents`
`enable_create_flush_agents`
`enable_create_outbox_replication_agents`