### PR TITLE
Lockdown version of ruby library `parallel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Lockdown version of ruby library `parallel` to `1.19.2` [#229]
 
 ## [3.16.0] - 2020-09-27
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'facter', '2.5.1', require: false
 gem 'faraday', '0.12.0.1', require: false
 gem 'inspec', '2.3.10', require: false
 gem 'metadata-json-lint', '2.2.0', require: false
+gem 'parallel', '1.19.2', require: false
 gem 'puppet', '5.5.21', require: false
 gem 'puppet-lint', '2.3.6', require: false
 gem 'puppetlabs_spec_helper', '2.14.1', require: false


### PR DESCRIPTION
### Changed
- Lockdown version of ruby library `parallel` to `1.19.2` [#229]