### PR TITLE
Fix 226/jdk8 all version support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lockdown version of ruby library `parallel` to `1.19.2` [#229]
 - Update Java installation manifests to support all Oracle Java JDK8 versions [#226]
 
+### Fixed
+- Fixed libjvm path to Oracle JDK11
+
 ## [3.16.0] - 2020-09-27
 ### Added
 - Add new AEM profile: aem65_sp6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Lockdown version of ruby library `parallel` to `1.19.2` [#229]
+- Update Java installation manifests to support all Oracle Java JDK8 versions [#226]
 
 ## [3.16.0] - 2020-09-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Java installation manifests to support all Oracle Java JDK8 versions [#226]
 
 ### Fixed
+- Fixed cacert path to Oracle JDK11
 - Fixed libjvm path to Oracle JDK11
 
 ## [3.16.0] - 2020-09-27

--- a/manifests/install_aem_java.pp
+++ b/manifests/install_aem_java.pp
@@ -42,7 +42,14 @@ class aem_curator::install_aem_java (
       $jdk_version_splitted = split($jdk_version, 'u')
       $jdk_version_major = $jdk_version_splitted[0]
       $jdk_version_update = $jdk_version_splitted[1]
-      $java_home_path = "/usr/java/jdk1.${jdk_version_major}.0_${jdk_version_update}-amd64/jre"
+      # Support of different JDK8 versions with different binary pathes
+      if Integer($jdk_version_update) >= 261 {
+        $java_home_path = "/usr/java/jdk1.${jdk_version_major}.0_${jdk_version_update}-amd64"
+      } elsif Integer($jdk_version_update) <= 162 {
+        $java_home_path = "/usr/java/jdk1.${jdk_version_major}.0_${jdk_version_update}/jre"
+      } else {
+        $java_home_path = "/usr/java/jdk1.${jdk_version_major}.0_${jdk_version_update}-amd64/jre"
+      }
       $libjvm_content_path= "${java_home_path}/lib/amd64/server/\n"
     }
     /^11/:

--- a/manifests/install_aem_java.pp
+++ b/manifests/install_aem_java.pp
@@ -46,12 +46,15 @@ class aem_curator::install_aem_java (
       if Integer($jdk_version_update) >= 261 {
         $java_home_path = "/usr/java/jdk1.${jdk_version_major}.0_${jdk_version_update}-amd64"
         $libjvm_content_path= "${java_home_path}/jre/lib/amd64/server/\n"
+        $cacert_path = "${java_home_path}/jre/lib/security/cacerts"
       } elsif Integer($jdk_version_update) <= 162 {
         $java_home_path = "/usr/java/jdk1.${jdk_version_major}.0_${jdk_version_update}/jre"
         $libjvm_content_path= "${java_home_path}/lib/amd64/server/\n"
+        $cacert_path = "${java_home_path}/lib/security/cacerts"
       } else {
         $java_home_path = "/usr/java/jdk1.${jdk_version_major}.0_${jdk_version_update}-amd64/jre"
         $libjvm_content_path= "${java_home_path}/lib/amd64/server/\n"
+        $cacert_path = "${java_home_path}/lib/security/cacerts"
       }
     }
     /^11/:
@@ -63,6 +66,7 @@ class aem_curator::install_aem_java (
       $jdk_version = $jdk_version_raw[0]
       $java_home_path = "/usr/java/jdk-${jdk_version}"
       $libjvm_content_path= "${java_home_path}/lib/server/\n"
+      $cacert_path = "${java_home_path}/lib/security/cacerts"
     }
     default: {
       fail('Error: Unknown Java Version. Supported java versions are : ( 8 | 11 )')
@@ -103,7 +107,7 @@ class aem_curator::install_aem_java (
       ensure  => present,
       source  => "${cert_base_url}/aem.${part}",
       require => File["${tmp_dir}/java"],
-    } -> java_ks { "cqse-${idx}:${java_home_path}/lib/security/cacerts":
+    } -> java_ks { "cqse-${idx}:${cacert_path}":
       ensure      => latest,
       certificate => "${tmp_dir}/java/aem.${part}",
       password    => 'changeit',

--- a/manifests/install_aem_java.pp
+++ b/manifests/install_aem_java.pp
@@ -45,12 +45,14 @@ class aem_curator::install_aem_java (
       # Support of different JDK8 versions with different binary pathes
       if Integer($jdk_version_update) >= 261 {
         $java_home_path = "/usr/java/jdk1.${jdk_version_major}.0_${jdk_version_update}-amd64"
+        $libjvm_content_path= "${java_home_path}/jre/lib/amd64/server/\n"
       } elsif Integer($jdk_version_update) <= 162 {
         $java_home_path = "/usr/java/jdk1.${jdk_version_major}.0_${jdk_version_update}/jre"
+        $libjvm_content_path= "${java_home_path}/lib/amd64/server/\n"
       } else {
         $java_home_path = "/usr/java/jdk1.${jdk_version_major}.0_${jdk_version_update}-amd64/jre"
+        $libjvm_content_path= "${java_home_path}/lib/amd64/server/\n"
       }
-      $libjvm_content_path= "${java_home_path}/lib/amd64/server/\n"
     }
     /^11/:
     {

--- a/manifests/install_java.pp
+++ b/manifests/install_java.pp
@@ -30,12 +30,19 @@ class aem_curator::install_java (
   $jdk_version_build  = '',
   $jdk_format         = 'rpm',
 ) {
-
+  # Support of different JDK8 versions with different binary pathes
+  if Integer($jdk_version_update) >= 261 {
+    $java_home_path = "/usr/java/jdk1.${jdk_version}.0_${jdk_version_update}-amd64"
+  } elsif Integer($jdk_version_update) <= 162 {
+    $java_home_path = "/usr/java/jdk1.${jdk_version}.0_${jdk_version_update}/jre"
+  } else {
+    $java_home_path = "/usr/java/jdk1.${jdk_version}.0_${jdk_version_update}-amd64/jre"
+  }
   java::download { $jdk_version :
     ensure  => 'present',
     java_se => 'jdk',
     url     => "${jdk_base_url}/${jdk_filename}",
-  } -> exec { "alternatives --set  java /usr/java/jdk1.${jdk_version}.0_${jdk_version_update}-amd64/jre/bin/java":
+  } -> exec { "alternatives --set  java ${java_home_path}/bin/java":
     path    => [ '/bin', '/sbin', '/usr/bin', '/usr/sbin' ],
     require => Java::Download[$jdk_version],
   }

--- a/manifests/install_java.pp
+++ b/manifests/install_java.pp
@@ -33,10 +33,13 @@ class aem_curator::install_java (
   # Support of different JDK8 versions with different binary pathes
   if Integer($jdk_version_update) >= 261 {
     $java_home_path = "/usr/java/jdk1.${jdk_version}.0_${jdk_version_update}-amd64"
+    $libjvm_content_path= "${java_home_path}/jre/lib/amd64/server/\n"
   } elsif Integer($jdk_version_update) <= 162 {
     $java_home_path = "/usr/java/jdk1.${jdk_version}.0_${jdk_version_update}/jre"
+    $libjvm_content_path= "${java_home_path}/lib/amd64/server/\n"
   } else {
     $java_home_path = "/usr/java/jdk1.${jdk_version}.0_${jdk_version_update}-amd64/jre"
+    $libjvm_content_path= "${java_home_path}/lib/amd64/server/\n"
   }
   java::download { $jdk_version :
     ensure  => 'present',
@@ -49,7 +52,7 @@ class aem_curator::install_java (
 
   file { '/etc/ld.so.conf.d/99-libjvm.conf':
     ensure  => present,
-    content => "/usr/java/latest/jre/lib/amd64/server\n",
+    content => $libjvm_content_path,
     notify  => Exec['/sbin/ldconfig'],
   }
 

--- a/manifests/install_java.pp
+++ b/manifests/install_java.pp
@@ -34,12 +34,15 @@ class aem_curator::install_java (
   if Integer($jdk_version_update) >= 261 {
     $java_home_path = "/usr/java/jdk1.${jdk_version}.0_${jdk_version_update}-amd64"
     $libjvm_content_path= "${java_home_path}/jre/lib/amd64/server/\n"
+    $cacert_path = "${java_home_path}/jre/lib/security/cacerts"
   } elsif Integer($jdk_version_update) <= 162 {
     $java_home_path = "/usr/java/jdk1.${jdk_version}.0_${jdk_version_update}/jre"
     $libjvm_content_path= "${java_home_path}/lib/amd64/server/\n"
+    $cacert_path = "${java_home_path}/lib/security/cacerts"
   } else {
     $java_home_path = "/usr/java/jdk1.${jdk_version}.0_${jdk_version_update}-amd64/jre"
     $libjvm_content_path= "${java_home_path}/lib/amd64/server/\n"
+    $cacert_path = "${java_home_path}/lib/security/cacerts"
   }
   java::download { $jdk_version :
     ensure  => 'present',
@@ -70,7 +73,7 @@ class aem_curator::install_java (
       ensure  => present,
       source  => "${cert_base_url}/aem.${part}",
       require => File[$tmp_dir],
-    } -> java_ks { "cqse-${idx}:/usr/java/default/jre/lib/security/cacerts":
+    } -> java_ks { "cqse-${idx}:${cacert_path}":
       ensure      => latest,
       certificate => "${tmp_dir}/aem.${part}",
       password    => 'changeit',


### PR DESCRIPTION
 ### Changed
- Update Java installation manifests to support all Oracle Java JDK8 versions [#226]

### Fixed
- Fixed cacert path to Oracle JDK11
- Fixed libjvm path to Oracle JDK11