### PR TITLE
Fixed syntax error in `action_promote_author_standby_to_primary`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed syntax error in `action_promote_author_standby_to_primary` manifest #RS-125
 
 ## [3.33.0] - 2023-02-15
 ### Added

--- a/manifests/action_promote_author_standby_to_primary.pp
+++ b/manifests/action_promote_author_standby_to_primary.pp
@@ -55,9 +55,9 @@ class aem_curator::action_promote_author_standby_to_primary (
   }
 
   class { 'aem_curator::config_collectd':
-    component       => 'author-primary',
-    collectd_prefix => "${stack_prefix}-author-primary",
-    ec2_id          => $ec2_id},
+    component         => 'author-primary',
+    collectd_prefix   => "${stack_prefix}-author-primary",
+    ec2_id            => $ec2_id,
     jmx_user          => $jmxremote_monitoring_username,
     jmx_user_password => $jmxremote_monitoring_user_password,
   }


### PR DESCRIPTION
### Fixed
- Fixed syntax error in `action_promote_author_standby_to_primary`  manifest #RS-125