### PR TITLE
Simplify GitHub Actions release workflows to not use custom action

### DIFF
--- a/.github/actions/release-major-action/Dockerfile
+++ b/.github/actions/release-major-action/Dockerfile
@@ -1,3 +1,0 @@
-FROM shinesolutions/aem-platform-buildenv:4.0.2
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/release-major-action/action.yaml
+++ b/.github/actions/release-major-action/action.yaml
@@ -1,4 +1,0 @@
-name: 'Release Major'
-runs:
-  using: 'docker'
-  image: 'Dockerfile'

--- a/.github/actions/release-major-action/entrypoint.sh
+++ b/.github/actions/release-major-action/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-git config --global user.email "opensource@shinesolutions.com"
-git config --global user.name "Shine Open Source"
-chown -R root:root /github/workspace
-make release-major

--- a/.github/actions/release-minor-action/Dockerfile
+++ b/.github/actions/release-minor-action/Dockerfile
@@ -1,3 +1,0 @@
-FROM shinesolutions/aem-platform-buildenv:4.0.2
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/release-minor-action/action.yaml
+++ b/.github/actions/release-minor-action/action.yaml
@@ -1,4 +1,0 @@
-name: 'Release Minor'
-runs:
-  using: 'docker'
-  image: 'Dockerfile'

--- a/.github/actions/release-minor-action/entrypoint.sh
+++ b/.github/actions/release-minor-action/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-git config --global user.email "opensource@shinesolutions.com"
-git config --global user.name "Shine Open Source"
-chown -R root:root /github/workspace
-make release-minor

--- a/.github/actions/release-patch-action/Dockerfile
+++ b/.github/actions/release-patch-action/Dockerfile
@@ -1,3 +1,0 @@
-FROM shinesolutions/aem-platform-buildenv:4.0.2
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/release-patch-action/action.yaml
+++ b/.github/actions/release-patch-action/action.yaml
@@ -1,4 +1,0 @@
-name: 'Release Patch'
-runs:
-  using: 'docker'
-  image: 'Dockerfile'

--- a/.github/actions/release-patch-action/entrypoint.sh
+++ b/.github/actions/release-patch-action/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-git config --global user.email "opensource@shinesolutions.com"
-git config --global user.name "Shine Open Source"
-chown -R root:root /github/workspace
-make release-patch

--- a/.github/workflows/release-major-workflow.yaml
+++ b/.github/workflows/release-major-workflow.yaml
@@ -8,6 +8,6 @@ jobs:
       - uses: cliffano/release-action@v2.0.0
         with:
           release_type: major
-          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          github_token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
           git_user_email: shinesworks@shinesolutions.com
           git_user_name: Shine Works

--- a/.github/workflows/release-major-workflow.yaml
+++ b/.github/workflows/release-major-workflow.yaml
@@ -3,20 +3,11 @@ name: Release Major
 on: [workflow_dispatch]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: cliffano/release-action@v2.0.0
         with:
-          token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-          set-safe-directory: ${{ github.workspace }}      
-      - uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: shinesolutions
-          password: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-      - uses: ./.github/actions/release-major-action
-      - uses: ad-m/github-push-action@master
-        with:
-          tags: true
-          github_token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+          release_type: major
+          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          git_user_email: shinesworks@shinesolutions.com
+          git_user_name: Shine Works

--- a/.github/workflows/release-minor-workflow.yaml
+++ b/.github/workflows/release-minor-workflow.yaml
@@ -8,6 +8,6 @@ jobs:
       - uses: cliffano/release-action@v2.0.0
         with:
           release_type: minor
-          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          github_token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
           git_user_email: shinesworks@shinesolutions.com
           git_user_name: Shine Works

--- a/.github/workflows/release-minor-workflow.yaml
+++ b/.github/workflows/release-minor-workflow.yaml
@@ -3,20 +3,11 @@ name: Release Minor
 on: [workflow_dispatch]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: cliffano/release-action@v2.0.0
         with:
-          token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-          set-safe-directory: ${{ github.workspace }}      
-      - uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: shinesolutions
-          password: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-      - uses: ./.github/actions/release-minor-action
-      - uses: ad-m/github-push-action@master
-        with:
-          tags: true
-          github_token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+          release_type: minor
+          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          git_user_email: shinesworks@shinesolutions.com
+          git_user_name: Shine Works

--- a/.github/workflows/release-patch-workflow.yaml
+++ b/.github/workflows/release-patch-workflow.yaml
@@ -8,6 +8,6 @@ jobs:
       - uses: cliffano/release-action@v2.0.0
         with:
           release_type: patch
-          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          github_token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
           git_user_email: shinesworks@shinesolutions.com
           git_user_name: Shine Works

--- a/.github/workflows/release-patch-workflow.yaml
+++ b/.github/workflows/release-patch-workflow.yaml
@@ -3,20 +3,11 @@ name: Release Patch
 on: [workflow_dispatch]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: cliffano/release-action@v2.0.0
         with:
-          token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-          set-safe-directory: ${{ github.workspace }}
-      - uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: shinesolutions
-          password: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-      - uses: ./.github/actions/release-patch-action
-      - uses: ad-m/github-push-action@master
-        with:
-          tags: true
-          github_token: ${{ secrets.SHINEOPENSOURCE_GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+          release_type: patch
+          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          git_user_email: shinesworks@shinesolutions.com
+          git_user_name: Shine Works

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Simplify GitHub Actions release workflows to not use custom action
+
 ## [4.1.9] - 2026-03-10
 ### Added
 - Added new AEM profile: aem65_sp22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Simplify GitHub Actions release workflows to not use custom action
 
+### Fixed
+- Fix release workflows to use SHINEOPENSOURCE_GITHUB_TOKEN instead of SHINEWORKS_GITHUB_TOKEN, matching this repo's original token
+
 ## [4.1.9] - 2026-03-10
 ### Added
 - Added new AEM profile: aem65_sp22


### PR DESCRIPTION
## Summary
- Simplify GitHub Actions release workflows to not use custom action
- Fix release workflow to use SHINEOPENSOURCE_GITHUB_TOKEN

Part of RS-204: uplift release workflows to the shared the-works-buildenv pattern.

## Test plan
- [ ] Confirm release-major/minor/patch workflows run correctly via workflow_dispatch after merge
